### PR TITLE
Move Happo from Tools & Frameworks to Online services

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [gatling](https://github.com/gabrielrotbart/gatling) - Integrated visual RSpec matcher which makes real visual testing easy (Ruby).
 - [grunt-photobox](https://github.com/stefanjudis/grunt-photobox) - Plugin to prevent your project of broken layout via screenshot photo sessions of your site.
 - [vrtest](https://github.com/nathanmarks/vrtest) - JavaScript library for running visual regression tests on your components cross browser via selenium.
-- [Happo](https://github.com/Galooshi/happo) - Visual diffing in CI for user interfaces.
 - [reg-cli](https://github.com/bokuweb/reg-cli) - Visual regression test tool which output easy-to-read single file html report.
 - [Nightmare](https://github.com/segmentio/nightmare) - High-level browser automation library based on Electron.
 - [Puppeteer](https://github.com/GoogleChrome/puppeteer) - Headless Google Chrome Node API.
@@ -72,8 +71,8 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Muppeteer](https://github.com/HuddleEng/Muppeteer) - Visual regression testing framework for Chrome using [Mocha](https://mochajs.org/) and [Puppeteer](https://github.com/GoogleChrome/puppeteer).
 - [ember-visual-test](https://github.com/Cropster/ember-visual-test) - Simple visual regression testing for [Ember](https://emberjs.com/).
 - [AET](https://github.com/Cognifide/aet) - Scalable testing tool providing visual regression testing, accessibility and performance validation, markup analysis and more.
-- [Wendigo](https://github.com/angrykoala/wendigo) - Test-oriented browser automation library based on Puppeteer. 
-- [Loki](https://github.com/oblador/loki) - Visual regression testing for Storybook using Chrome in docker et al. 
+- [Wendigo](https://github.com/angrykoala/wendigo) - Test-oriented browser automation library based on Puppeteer.
+- [Loki](https://github.com/oblador/loki) - Visual regression testing for Storybook using Chrome in docker et al.
 - [Zombie.js](http://zombie.js.org/) - Insanely fast, headless full-stack testing using Node.js.
 
 ## Online services
@@ -92,6 +91,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [BackTrac](https://backtrac.io) - Cloud based visual regression tool. Uses headless firefox and proprietary comparison algorithm (detect layout shifts).
 - [Chromatic](https://www.chromaticqa.com) - Visual testing and UI review for component libraries. Cloud-based. [Video](https://youtu.be/6KDLJBcutQE)
 - [VisWiz.io](https://www.viswiz.io) - Flexible visual regression testing service.
+- [Happo](https://happo.io/) - Cloud-based screenshot testing service with support for multiple browsers.
 
 ## Blog posts
 


### PR DESCRIPTION
While old Happo continues to be a thing, new development is done on the
happo.io service. Here are some of the things that are improved in new
Happo:

  - New Happo has support for multiple browsers.
  - Faster screenshooting with parallell rendering.
  - An enhanced diff review UI
  - Better integration with github.com

To prevent driving traffic to the old project which is only lightly
maintained these days, I'm updating the link. I'm also moving the entry
to the "Online services" section which is a better fit for happo.io.