### PR TITLE
Minor punctuation update for the code of conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -22,11 +22,11 @@ include:
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances.
-* Trolling, insulting/derogatory comments, and personal or political attacks.
-* Public or private harassment.
-* Publishing others' private information, such as a physical or electronic address, without explicit permission.
-* Other conduct which could reasonably be considered inappropriate in a professional setting.
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 


### PR DESCRIPTION
For uniformity, remove periods at the end of list items that are not complete sentences. See the Contributor Covenant at http://contributor-covenant.org/version/1/4 for reference. Also see the Our Standards section near the top of this file.