### PR TITLE
Move BacksstopJS to deprecated list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 
 - [AET](https://github.com/Cognifide/aet) - Scalable testing tool providing visual regression testing, accessibility and performance validation, markup analysis and more.
 - [AyeSpy](https://github.com/newsuk/ayespy) - 44 image comparisons in 90 seconds.
-- [BackstopJS](https://github.com/garris/BackstopJS) - Config-driven automated screenshot test framework.
 - [basset](https://basset.io) - Open source platform for generating and reviewing visual differences. Supports multiple browsers, integrations for github and slack.
 - [BitDive](https://bitdive.io/) - BitDive is a zero-code regression testing tool for Java/Kotlin applications. It captures real runtime behavior (methods, SQL, HTTP) and enables Live Context Replay with automatic mocking to detect semantic drift between versions.
 - [BFFless](https://bffless.app) - Self-hosted platform for hosting and viewing visual regression screenshots from CI/CD pipelines with GitHub Actions integration.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 
 The following projects are no longer maintained actively but are still worth mentioning because of their user base.
 
+- [BackstopJS](https://github.com/garris/BackstopJS) - Config-driven automated screenshot test framework.
 - [CasperJS](https://github.com/casperjs/casperjs) - Navigation scripting and testing utility for PhantomJS and SlimerJS. (archived 2018)
 - [Chromeless](https://github.com/graphcool/chromeless) - Chrome automation made simple. Runs locally or headless on AWS Lambda. (archived 2018)
 - [DalekJS](https://github.com/dalekjs/dalek) - Automated cross browser testing with JavaScript. No longer maintained since 4 Jun 2017.


### PR DESCRIPTION
project is unmaintained now, see https://github.com/garris/BackstopJS/issues/1618
<img width="968" height="301" alt="image" src="https://github.com/user-attachments/assets/4b590a22-a05d-4ee2-86cc-8a502eb92d4e" />
