### PR TITLE
Add Lastest to Tools and frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot) - Jest matcher that performs image comparisons using [pixelmatch](https://www.npmjs.com/package/pixelmatch)
 - [jest-puppeteer-react](https://github.com/Hapag-Lloyd/jest-puppeteer-react) - Visual regression testing with Jest and puppeteer for React components
 - [Karma](http://karma-runner.github.io/latest/index.html) - A test runner by the AngularJS team, that fits all our needs.
+- [Lastest](https://github.com/las-team/lastest) - Visual regression testing platform built on Playwright with screenshot diffing, baseline review, and AI flake triage. Self-hostable via docker-compose or k8s.
 - [Loki](https://github.com/oblador/loki) - Visual regression testing for Storybook using Chrome in docker et al.
 - [Look-alike](https://github.com/kdzwinel/Look-alike) - Chrome Extension for taking and comparing screenshots.
 - [Lost Pixel](https://github.com/lost-pixel/lost-pixel) - Holistic visual regression testing for full pages, components (via Storybook and Ladle integration), and custom shots (e.g. via Cypress).


### PR DESCRIPTION
Adds Lastest to the Tools and frameworks (a-z) section.

- Repo: https://github.com/las-team/lastest (MIT)
- Site: https://lastest.cloud
- Visual regression testing platform built on Playwright; screenshot diffing, baseline review, AI flake triage
- Self-hostable (docker-compose + k8s); cloud version also available

Inserted alphabetically between Karma and Loki. Description ends with a period per CONTRIBUTING.