### PR TITLE
Add CIAgent — regression testing for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [BitDive](https://bitdive.io/) - BitDive is a zero-code regression testing tool for Java/Kotlin applications. It captures real runtime behavior (methods, SQL, HTTP) and enables Live Context Replay with automatic mocking to detect semantic drift between versions.
 - [BFFless](https://bffless.app) - Self-hosted platform for hosting and viewing visual regression screenshots from CI/CD pipelines with GitHub Actions integration.
 - [Chimp](https://github.com/xolvio/chimp) - Develop acceptance tests & end-to-end tests with realtime feedback.
+- [CIAgent](https://github.com/suniel12/ciagent) - Pytest-native regression testing for AI agents. Records golden execution traces and catches behavior drift on re-runs: tool-call sequence changes, routing changes, cost spikes, and flaky verdicts with flip-source attribution.
 - [CodeceptJS](https://github.com/codeception/codeceptjs/) - Modern Era Acceptance Testing Framework for NodeJS.
 - [Creevey](https://github.com/wKich/creevey) - Cross-browser visual testing with magic. Feature-rich tool with UI Runner, Tests Hot Reloading, Docker and Storybook integration.
 - [CSSCritic](https://github.com/cburgmer/csscritic) - Lightweight CSS regression testing.


### PR DESCRIPTION
Adds **CIAgent** (`pip install ciagent`) — pytest-native regression testing for AI agents: golden-trace recording and diffing, cost guardrails, multi-run stability scoring with verdict-flip attribution, LLM-judge auditing, and one-command import of production traces (OpenTelemetry, Langfuse, LangSmith) into CI tests. Apache-2.0, active development, 900+ tests. Follows the list's format and ordering; one item, one PR.