### PR TITLE
Add dsh-verify — real-browser acceptance checks with screenshot receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [CSSCritic](https://github.com/cburgmer/csscritic) - Lightweight CSS regression testing.
 - [Differencify](https://github.com/NimaSoroush/differencify) - A library for visual regression testing using [Puppeteer](https://github.com/GoogleChrome/puppeteer).
 - [DiffGoblin Action](https://github.com/neg-0/diffgoblin-action) - GitHub Action that screenshots two URLs and posts a visual diff as a PR comment. Zero config, no external service needed.
+- [dsh-verify](https://github.com/263311487-ux/dsh-verify) - Real-browser acceptance checks for agent-built web apps, with screenshot + diff receipts. The browser is the judge — no LLM in the verdict.
 - [ember-visual-test](https://github.com/Cropster/ember-visual-test) - Simple visual regression testing for [Ember](https://emberjs.com/).
 - [FuncUnit](https://github.com/bitovi/funcunit) - A functional test suite based on jQuery
 - [Frostbyte Screenshot Action](https://github.com/OzorOwn/frostbyte-screenshot-action) - GitHub Action for automated website screenshots in CI/CD. API-based (no local browser), supports 5 viewports, full-page capture, dark mode.


### PR DESCRIPTION
## What

Adds [dsh-verify](https://github.com/263311487-ux/dsh-verify) to **Tools and frameworks** (alphabetical order, after DiffGoblin Action).

## Why

`dsh-verify` is an open-source quality gate for **agent-built web apps**: you write a JSON acceptance spec, a **real browser** executes it, and it returns a `PASS`/`FAIL` verdict with **screenshot + diff receipts**. No LLM judges the outcome — the browser is the judge.

It fits this list because the receipts are visual: screenshots and diff images that prove what changed between builds — which is exactly what catches the class of bugs visual regression exists for (e.g. a missing CSS rule that agents' self-review misses but a rendered page shows).

- Repo: https://github.com/263311487-ux/dsh-verify
- npm: https://www.npmjs.com/package/dsh-verify
- MCP server entry + CI + self-acceptance workflow in the README

## Checklist

- [x] Checked contributing guidance
- [x] Alphabetical order maintained
- [x] Format matches existing entries (`- [Name](url) - description`)